### PR TITLE
Lenvill's Ignition Patch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,10 @@ minecraft {
     }
 }
 
+sourceSets.all {
+    it.output.resourcesDir = it.output.classesDirs.getFiles().iterator().next()
+}
+
 repositories {
     google()
     mavenCentral()
@@ -181,7 +185,6 @@ dependencies {
 
     //// Dependencies ////
 
-    implementation fg.deobf("mezz.jei:jei_${mc_version}:${jei_version}")
     implementation fg.deobf("mezz.jei:jei_${mc_version}:${jei_version}")
 
     implementation fg.deobf("codechicken:CodeChickenLib:${mc_version}-${ccl_version}:universal")

--- a/src/main/java/minefantasy/mfr/api/crafting/IIgnitable.java
+++ b/src/main/java/minefantasy/mfr/api/crafting/IIgnitable.java
@@ -1,0 +1,26 @@
+package minefantasy.mfr.api.crafting;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.Random;
+
+public interface IIgnitable {
+
+    /**
+     * Standardized function to handle block ignition
+     * @param world World
+     * @param pos BlockPos
+     * @param state IBlockState
+     */
+    void fireItUp(World world, BlockPos pos, IBlockState state);
+
+    static void playIgnitionSound (World world, BlockPos pos) {
+        Random rand = new Random();
+        float pitch = (0.2F + (0.4F * rand.nextFloat()));
+        world.playSound(null, pos, SoundEvents.ITEM_FIRECHARGE_USE, SoundCategory.AMBIENT, 0.33F, pitch);
+    }
+}

--- a/src/main/java/minefantasy/mfr/api/crafting/IIgnitable.java
+++ b/src/main/java/minefantasy/mfr/api/crafting/IIgnitable.java
@@ -16,7 +16,7 @@ public interface IIgnitable {
      * @param pos BlockPos
      * @param state IBlockState
      */
-    void fireItUp(World world, BlockPos pos, IBlockState state);
+    void igniteBlock(World world, BlockPos pos, IBlockState state);
 
     static void playIgnitionSound (World world, BlockPos pos) {
         Random rand = new Random();

--- a/src/main/java/minefantasy/mfr/block/BlockBloomery.java
+++ b/src/main/java/minefantasy/mfr/block/BlockBloomery.java
@@ -104,7 +104,7 @@ public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> implement
 	public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
 		TileEntityBloomery tile = (TileEntityBloomery) getTile(world, pos);
 		if (tile != null) {
-			/// Handle Researches
+			// Handle Researches
 			Set<String> playerResearches = new HashSet<>();
 			for (String bloomeryResearch : CraftingManagerBloomery.getBloomeryResearches()) {
 				if (ResearchLogic.getResearchCheck(player, ResearchLogic.getResearch(bloomeryResearch))) {
@@ -115,26 +115,26 @@ public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> implement
 
 			ItemStack held = player.getHeldItem(hand);
 
-			/// Hammer
+			// Hammer
 			if (!player.isSwingInProgress && tile.tryHammer(player)) {
 				return true;
 			}
-			/// Ignition
+			// Ignition
 			if (held.getItem() instanceof ItemFlintAndSteel || held.getItem() instanceof ILighter) {
 				if (!tile.getIsActive() && tile.getResult() != ItemStack.EMPTY) {
+					// 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
 					int uses = ItemLighter.tryUse(held, player);
-					if (uses != 0) // 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
-					{
+					if (uses != 0) {
 						player.playSound(SoundEvents.ITEM_FLINTANDSTEEL_USE, 1.0F, 1.0F);
 						if (uses == 1 && !world.isRemote) {
 							held.damageItem(1, player);
-							fireItUp(world, pos, state);
+							igniteBlock(world, pos, state);
 						}
 					}
 					return true;
 				}
 			}
-			/// GUI
+			// GUI
 			if (!world.isRemote && !tile.getIsActive() && !tile.hasBloom()) {
 				final TileEntityBloomery tileEntity = (TileEntityBloomery) getTile(world, pos);
 				if (tileEntity != null) {
@@ -152,7 +152,7 @@ public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> implement
 	 * @param state IBlockState
 	 */
 	@Override
-	public void fireItUp(World world, BlockPos pos, IBlockState state) {
+	public void igniteBlock(World world, BlockPos pos, IBlockState state) {
 		TileEntityBloomery bloomery = (TileEntityBloomery) getTile(world, pos);
 		if (bloomery != null) {
 			boolean sky = world.canBlockSeeSky(pos.add(0, 1, 0));

--- a/src/main/java/minefantasy/mfr/block/BlockBloomery.java
+++ b/src/main/java/minefantasy/mfr/block/BlockBloomery.java
@@ -1,5 +1,7 @@
 package minefantasy.mfr.block;
 
+import minefantasy.mfr.api.crafting.IIgnitable;
+import minefantasy.mfr.api.tool.ILighter;
 import minefantasy.mfr.init.MineFantasyTabs;
 import minefantasy.mfr.item.ItemLighter;
 import minefantasy.mfr.mechanics.knowledge.ResearchLogic;
@@ -14,6 +16,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
+import net.minecraft.item.ItemFlintAndSteel;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
@@ -27,7 +30,7 @@ import javax.annotation.Nonnull;
 import java.util.HashSet;
 import java.util.Set;
 
-public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> {
+public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> implements IIgnitable {
 	public static final PropertyBool BLOOM = PropertyBool.create("bloom");
 
 	public BlockBloomery() {
@@ -101,7 +104,7 @@ public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> {
 	public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
 		TileEntityBloomery tile = (TileEntityBloomery) getTile(world, pos);
 		if (tile != null) {
-			// Handle Researches
+			/// Handle Researches
 			Set<String> playerResearches = new HashSet<>();
 			for (String bloomeryResearch : CraftingManagerBloomery.getBloomeryResearches()) {
 				if (ResearchLogic.getResearchCheck(player, ResearchLogic.getResearch(bloomeryResearch))) {
@@ -112,31 +115,58 @@ public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> {
 
 			ItemStack held = player.getHeldItem(hand);
 
-			// Hammer
+			/// Hammer
 			if (!player.isSwingInProgress && tile.tryHammer(player)) {
 				return true;
 			}
-			// Light
-			int l = ItemLighter.tryUse(held, player);
-			if (!tile.isActive() && !tile.hasBloom()) {
-				if (!held.isEmpty() && l != 0) {
-					player.playSound(SoundEvents.ITEM_FLINTANDSTEEL_USE, 1.0F, 1.0F);
-					if (world.isRemote)
-						return true;
-					if (l == 1 && tile.light(player)) {
-						held.damageItem(1, player);
+			/// Ignition
+			if (held.getItem() instanceof ItemFlintAndSteel || held.getItem() instanceof ILighter) {
+				if (!tile.getIsActive() && tile.getResult() != ItemStack.EMPTY) {
+					int uses = ItemLighter.tryUse(held, player);
+					if (uses != 0) // 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
+					{
+						player.playSound(SoundEvents.ITEM_FLINTANDSTEEL_USE, 1.0F, 1.0F);
+						if (uses == 1 && !world.isRemote) {
+							held.damageItem(1, player);
+							fireItUp(world, pos, state);
+						}
 					}
 					return true;
 				}
 			}
-			// GUI
-			if (!world.isRemote && !tile.isActive() && !tile.hasBloom()) {
+			/// GUI
+			if (!world.isRemote && !tile.getIsActive() && !tile.hasBloom()) {
 				final TileEntityBloomery tileEntity = (TileEntityBloomery) getTile(world, pos);
 				if (tileEntity != null) {
 					tileEntity.openGUI(world, player);
 				}
 			}
 		}
+		return true;
+	}
+
+	/**
+	 * Standardized function to handle block ignition
+	 * @param world World
+	 * @param pos BlockPos
+	 * @param state IBlockState
+	 */
+	@Override
+	public void fireItUp(World world, BlockPos pos, IBlockState state) {
+		TileEntityBloomery bloomery = (TileEntityBloomery) getTile(world, pos);
+		if (bloomery != null) {
+			boolean sky = world.canBlockSeeSky(pos.add(0, 1, 0));
+			ItemStack result = bloomery.getResult();
+			if (!bloomery.getIsActive() && sky && !state.getValue(BLOOM) && result != ItemStack.EMPTY) {
+				IIgnitable.playIgnitionSound(world, pos);
+				bloomery.setIsActive(true);
+				bloomery.setProgressMax(bloomery.getSmeltTime());
+			}
+		}
+	}
+
+	public boolean doesPlayerHaveResearch() {
+		// Empty function for TPK to populate with a proper check to see if the igniting player has the right research
 		return true;
 	}
 
@@ -149,5 +179,4 @@ public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> {
 			}
 		}
 	}
-
 }

--- a/src/main/java/minefantasy/mfr/block/BlockBloomery.java
+++ b/src/main/java/minefantasy/mfr/block/BlockBloomery.java
@@ -121,7 +121,7 @@ public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> implement
 			}
 			// Ignition
 			if (held.getItem() instanceof ItemFlintAndSteel || held.getItem() instanceof ILighter) {
-				if (!tile.getIsActive() && tile.getResult() != ItemStack.EMPTY) {
+				if (!tile.isActive() && tile.getResult() != ItemStack.EMPTY) {
 					// 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
 					int uses = ItemLighter.tryUse(held, player);
 					if (uses != 0) {
@@ -135,7 +135,7 @@ public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> implement
 				}
 			}
 			// GUI
-			if (!world.isRemote && !tile.getIsActive() && !tile.hasBloom()) {
+			if (!world.isRemote && !tile.isActive() && !tile.hasBloom()) {
 				final TileEntityBloomery tileEntity = (TileEntityBloomery) getTile(world, pos);
 				if (tileEntity != null) {
 					tileEntity.openGUI(world, player);
@@ -157,7 +157,7 @@ public class BlockBloomery extends BlockTileEntity<TileEntityBloomery> implement
 		if (bloomery != null) {
 			boolean sky = world.canBlockSeeSky(pos.add(0, 1, 0));
 			ItemStack result = bloomery.getResult();
-			if (!bloomery.getIsActive() && sky && !state.getValue(BLOOM) && result != ItemStack.EMPTY) {
+			if (!bloomery.isActive() && sky && !state.getValue(BLOOM) && result != ItemStack.EMPTY) {
 				IIgnitable.playIgnitionSound(world, pos);
 				bloomery.setIsActive(true);
 				bloomery.setProgressMax(bloomery.getSmeltTime());

--- a/src/main/java/minefantasy/mfr/block/BlockFirepit.java
+++ b/src/main/java/minefantasy/mfr/block/BlockFirepit.java
@@ -125,7 +125,7 @@ public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> implements 
 			boolean burning = firepit.isBurning();
 
 			if (!held.isEmpty()) {
-				/// Adding fuel
+				// Adding fuel
 				if (firepit.addFuel(held) && !player.capabilities.isCreativeMode) {
 					if (!world.isRemote) {
 						if (held.getCount() == 1) {
@@ -146,7 +146,7 @@ public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> implements 
 					return true;
 				}
 
-				/// Cooking
+				// Cooking
 				if (burning) {
 					if (firepit.tryCook(player, held) && !player.capabilities.isCreativeMode) {
 						ItemStack contain = held.getItem().getContainerItem(held);
@@ -161,17 +161,17 @@ public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> implements 
 						}
 					}
 					return true;
-				/// Ignition
+				// Ignition
 				} else {
 					if (held.getItem() instanceof ItemFlintAndSteel || held.getItem() instanceof ILighter) {
 						int uses = ItemLighter.tryUse(held, player);
-						if (uses != 0 && firepit.fuel > 0) // 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
-						{
+						// 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
+						if (uses != 0 && firepit.fuel > 0) {
 							player.playSound(SoundEvents.ITEM_FLINTANDSTEEL_USE, 1.0F, 1.0F);
 							world.spawnParticle(EnumParticleTypes.FLAME, pos.getX() + 0.5D, pos.getY() - 0.5D, pos.getZ() + 0.5D, 0F, 0F, 0F);
 							if (uses == 1 && !world.isRemote) {
 								held.damageItem(1, player);
-								fireItUp(world, pos, state);
+								igniteBlock(world, pos, state);
 							}
 						}
 						return true;
@@ -189,7 +189,7 @@ public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> implements 
 	 * @param state IBlockState
 	 */
 	@Override
-	public void fireItUp(World world, BlockPos pos, IBlockState state) {
+	public void igniteBlock(World world, BlockPos pos, IBlockState state) {
 		TileEntityFirepit firepit = (TileEntityFirepit) getTile(world, pos);
 		if (firepit != null) {
 			if (firepit.isWet()  && firepit.fuel > 0) {

--- a/src/main/java/minefantasy/mfr/block/BlockFirepit.java
+++ b/src/main/java/minefantasy/mfr/block/BlockFirepit.java
@@ -1,7 +1,9 @@
 package minefantasy.mfr.block;
 
+import minefantasy.mfr.api.crafting.IIgnitable;
 import minefantasy.mfr.api.tool.ILighter;
 import minefantasy.mfr.init.MineFantasyTabs;
+import minefantasy.mfr.item.ItemLighter;
 import minefantasy.mfr.tile.TileEntityFirepit;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
@@ -32,7 +34,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nonnull;
 import java.util.Random;
 
-public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> {
+public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> implements IIgnitable {
 	private static final PropertyBool BURNING = PropertyBool.create("burning");
 	private static final PropertyBool PLANKS = PropertyBool.create("planks");
 	private static final PropertyBool UNDER = PropertyBool.create("under");
@@ -123,6 +125,7 @@ public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> {
 			boolean burning = firepit.isBurning();
 
 			if (!held.isEmpty()) {
+				/// Adding fuel
 				if (firepit.addFuel(held) && !player.capabilities.isCreativeMode) {
 					if (!world.isRemote) {
 						if (held.getCount() == 1) {
@@ -143,6 +146,7 @@ public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> {
 					return true;
 				}
 
+				/// Cooking
 				if (burning) {
 					if (firepit.tryCook(player, held) && !player.capabilities.isCreativeMode) {
 						ItemStack contain = held.getItem().getContainerItem(held);
@@ -157,29 +161,18 @@ public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> {
 						}
 					}
 					return true;
-				} else if (firepit.fuel > 0) {
-					if (held.getItem() instanceof ILighter) {
-						world.playSound(player, pos, SoundEvents.ITEM_FIRECHARGE_USE, SoundCategory.AMBIENT, 1.0F, rand.nextFloat() * 0.4F + 0.8F);
-						world.spawnParticle(EnumParticleTypes.FLAME, pos.getX() + 0.5D, pos.getY() - 0.5D, pos.getZ() + 0.5D, 0F, 0.1F, 0F);
-
-						ILighter lighter = (ILighter) held.getItem();
-						if (lighter.canLight()) {
-							if (rand.nextDouble() < lighter.getChance()) {
-								if (!world.isRemote) {
-									firepit.setLit(true);
-									held.damageItem(1, player);
-								}
+				/// Ignition
+				} else {
+					if (held.getItem() instanceof ItemFlintAndSteel || held.getItem() instanceof ILighter) {
+						int uses = ItemLighter.tryUse(held, player);
+						if (uses != 0 && firepit.fuel > 0) // 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
+						{
+							player.playSound(SoundEvents.ITEM_FLINTANDSTEEL_USE, 1.0F, 1.0F);
+							world.spawnParticle(EnumParticleTypes.FLAME, pos.getX() + 0.5D, pos.getY() - 0.5D, pos.getZ() + 0.5D, 0F, 0F, 0F);
+							if (uses == 1 && !world.isRemote) {
+								held.damageItem(1, player);
+								fireItUp(world, pos, state);
 							}
-							return true;
-						}
-					}
-					if (held.getItem() instanceof ItemFlintAndSteel) {
-						world.playSound(player, pos, SoundEvents.ITEM_FIRECHARGE_USE, SoundCategory.AMBIENT, 1.0F, rand.nextFloat() * 0.4F + 0.8F);
-						world.spawnParticle(EnumParticleTypes.FLAME, pos.getX() + 0.5D, pos.getY() - 0.5D, pos.getZ() + 0.5D, 0F, 0F, 0F);
-
-						if (!world.isRemote) {
-							firepit.setLit(true);
-							held.damageItem(1, player);
 						}
 						return true;
 					}
@@ -187,6 +180,26 @@ public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> {
 			}
 		}
 		return super.onBlockActivated(world, pos, state, player, hand, facing, hitX, hitY, hitZ);
+	}
+
+	/**
+	 * Standardized function to handle block ignition
+	 * @param world World
+	 * @param pos BlockPos
+	 * @param state IBlockState
+	 */
+	@Override
+	public void fireItUp(World world, BlockPos pos, IBlockState state) {
+		TileEntityFirepit firepit = (TileEntityFirepit) getTile(world, pos);
+		if (firepit != null) {
+			if (firepit.isWet()  && firepit.fuel > 0) {
+				world.playSound(null, pos, SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.AMBIENT, 0.5F, 1.0F);
+			} else if (!state.getValue(BURNING) && firepit.fuel > 0) {
+				IIgnitable.playIgnitionSound(world, pos);
+				firepit.setIsLit(true);
+				setActiveState(true, true, firepit.hasBlockAbove(), world, pos);
+			}
+		}
 	}
 
 	@Override
@@ -226,7 +239,7 @@ public class BlockFirepit extends BlockTileEntity<TileEntityFirepit> {
 	@Override
 	@SideOnly(Side.CLIENT)
 	public void randomDisplayTick(IBlockState state, World world, BlockPos pos, Random random) {
-		if (world.getTileEntity(pos) instanceof TileEntityFirepit && !(((TileEntityFirepit) world.getTileEntity(pos)).isLit())) {
+		if (world.getTileEntity(pos) instanceof TileEntityFirepit && !(((TileEntityFirepit) world.getTileEntity(pos)).getIsLit())) {
 			return;
 		}
 		if (rand.nextInt(10) == 0) {

--- a/src/main/java/minefantasy/mfr/block/BlockForge.java
+++ b/src/main/java/minefantasy/mfr/block/BlockForge.java
@@ -174,7 +174,7 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 		ItemStack held = player.getHeldItemMainhand();
 		TileEntityForge forge = (TileEntityForge) getTile(world, pos);
 		if (forge != null) {
-			/// Burn unprotected players
+			// Burn unprotected players
 			if (forge.getIsLit() && !ItemApron.isUserProtected(player)) {
 				player.setFire(5);
 				player.attackEntityFrom(DamageSource.ON_FIRE, player.isWet() ? 3 : 1);
@@ -183,26 +183,26 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 				}
 			}
 			if (!held.isEmpty()) {
-				/// Tong use
+				// Tong use
 				if (facing == EnumFacing.UP && held.getItem() instanceof ItemTongs && onUsedTongs(player, held, forge)) {
 					return true;
 				}
-				/// Ignition
+				// Ignition
 				if (held.getItem() instanceof ItemFlintAndSteel || held.getItem() instanceof ILighter) {
 					if (!forge.getIsLit() && forge.getFuel() > 0 && forge.getTier() != 1) {
+						// 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
 						int uses = ItemLighter.tryUse(held, player);
-						if (uses != 0) // 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
-						{
+						if (uses != 0) {
 							player.playSound(SoundEvents.ITEM_FLINTANDSTEEL_USE, 1.0F, 1.0F);
 							if (uses == 1 && !world.isRemote) {
 								held.damageItem(1, player);
-								fireItUp(world, pos, state);
+								igniteBlock(world, pos, state);
 							}
 						}
 						return true;
 					}
 				}
-				/// Adding heatable items
+				// Adding heatable items
 				if (Heatable.canHeatItem(held) && forge.tryAddHeatable(held)) {
 					held.shrink(1);
 					if (held.getCount() <= 0) {
@@ -211,7 +211,7 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 					return true;
 				}
 
-				/// Adding fuel
+				// Adding fuel
 				ForgeFuel stats = ForgeItemHandler.getStats(held);
 				if (stats != null && forge.addFuel(stats, true)) {
 					if (player.capabilities.isCreativeMode) {
@@ -237,7 +237,7 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 					return true;
 				}
 			}
-			/// Open GUI
+			// Open GUI
 			if (!world.isRemote && !forge.hasBlockAbove()) {
 				TileEntityForge tileEntity = (TileEntityForge) getTile(world, pos);
 				if (tileEntity != null) {
@@ -255,7 +255,7 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 	 * @param state IBlockState
 	 */
 	@Override
-	public void fireItUp(World world, BlockPos pos, IBlockState state) {
+	public void igniteBlock(World world, BlockPos pos, IBlockState state) {
 		TileEntityForge forge = (TileEntityForge) getTile(world, pos);
 		if (forge != null) {
 			if (world.isRainingAt(pos.add(0, 1, 0)) && forge.getFuel() > 0) {
@@ -319,7 +319,7 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 				tile.setIsLit(false);
 				world.playSound(null, pos, SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.AMBIENT, 0.5F, 1.0F);
 			} else if (!tile.getIsLit() && world.isBlockPowered(pos)) {
-				fireItUp(world, pos, state);
+				igniteBlock(world, pos, state);
 				world.playSound(null, pos, SoundEvents.ITEM_FLINTANDSTEEL_USE, SoundCategory.AMBIENT, 1.0F, 1.0F);
 			}
 		}

--- a/src/main/java/minefantasy/mfr/block/BlockForge.java
+++ b/src/main/java/minefantasy/mfr/block/BlockForge.java
@@ -1,9 +1,11 @@
 package minefantasy.mfr.block;
 
+import minefantasy.mfr.api.crafting.IIgnitable;
 import minefantasy.mfr.api.heating.ForgeFuel;
 import minefantasy.mfr.api.heating.ForgeItemHandler;
 import minefantasy.mfr.api.heating.Heatable;
 import minefantasy.mfr.api.heating.TongsHelper;
+import minefantasy.mfr.api.tool.ILighter;
 import minefantasy.mfr.init.MineFantasyItems;
 import minefantasy.mfr.init.MineFantasyTabs;
 import minefantasy.mfr.item.ItemApron;
@@ -22,12 +24,10 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemFlintAndSteel;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
-import net.minecraft.util.EnumParticleTypes;
+import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -39,7 +39,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nonnull;
 import java.util.Random;
 
-public class BlockForge extends BlockTileEntity<TileEntityForge> {
+public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgnitable {
 	private static final PropertyBool BURNING = PropertyBool.create("burning");
 	public static final PropertyBool UNDER = PropertyBool.create("under");
 	private static final PropertyInteger FUEL_COUNT = PropertyInteger.create("fuel_count", 0, 3);
@@ -172,9 +172,10 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> {
 	@Override
 	public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
 		ItemStack held = player.getHeldItemMainhand();
-		TileEntityForge tile = (TileEntityForge) getTile(world, pos);
-		if (tile != null) {
-			if (tile.getIsLit() && !ItemApron.isUserProtected(player)) {
+		TileEntityForge forge = (TileEntityForge) getTile(world, pos);
+		if (forge != null) {
+			/// Burn unprotected players
+			if (forge.getIsLit() && !ItemApron.isUserProtected(player)) {
 				player.setFire(5);
 				player.attackEntityFrom(DamageSource.ON_FIRE, player.isWet() ? 3 : 1);
 				if (!player.world.isRemote) {
@@ -182,19 +183,27 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> {
 				}
 			}
 			if (!held.isEmpty()) {
-				if (facing == EnumFacing.UP && held.getItem() instanceof ItemTongs && onUsedTongs(player, held, tile)) {
+				/// Tong use
+				if (facing == EnumFacing.UP && held.getItem() instanceof ItemTongs && onUsedTongs(player, held, forge)) {
 					return true;
 				}
-				int uses = ItemLighter.tryUse(held, player);
-				if (!tile.getIsLit() && uses != 0) {
-					player.playSound(SoundEvents.ITEM_FLINTANDSTEEL_USE, 1.0F, 1.0F);
-					if (uses == 1) {
-						tile.fireUpForge();
-						held.damageItem(1, player);
+				/// Ignition
+				if (held.getItem() instanceof ItemFlintAndSteel || held.getItem() instanceof ILighter) {
+					if (!forge.getIsLit() && forge.getFuel() > 0 && forge.getTier() != 1) {
+						int uses = ItemLighter.tryUse(held, player);
+						if (uses != 0) // 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
+						{
+							player.playSound(SoundEvents.ITEM_FLINTANDSTEEL_USE, 1.0F, 1.0F);
+							if (uses == 1 && !world.isRemote) {
+								held.damageItem(1, player);
+								fireItUp(world, pos, state);
+							}
+						}
+						return true;
 					}
-					return true;
 				}
-				if (Heatable.canHeatItem(held) && tile.tryAddHeatable(held)) {
+				/// Adding heatable items
+				if (Heatable.canHeatItem(held) && forge.tryAddHeatable(held)) {
 					held.shrink(1);
 					if (held.getCount() <= 0) {
 						player.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, ItemStack.EMPTY);
@@ -202,8 +211,9 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> {
 					return true;
 				}
 
+				/// Adding fuel
 				ForgeFuel stats = ForgeItemHandler.getStats(held);
-				if (stats != null && tile.addFuel(stats, true)) {
+				if (stats != null && forge.addFuel(stats, true)) {
 					if (player.capabilities.isCreativeMode) {
 						return true;
 					}
@@ -227,7 +237,8 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> {
 					return true;
 				}
 			}
-			if (!world.isRemote && !tile.hasBlockAbove()) {
+			/// Open GUI
+			if (!world.isRemote && !forge.hasBlockAbove()) {
 				TileEntityForge tileEntity = (TileEntityForge) getTile(world, pos);
 				if (tileEntity != null) {
 					tileEntity.openGUI(world, player);
@@ -235,6 +246,27 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Standardized function to handle block ignition
+	 * @param world World
+	 * @param pos BlockPos
+	 * @param state IBlockState
+	 */
+	@Override
+	public void fireItUp(World world, BlockPos pos, IBlockState state) {
+		TileEntityForge forge = (TileEntityForge) getTile(world, pos);
+		if (forge != null) {
+			if (world.isRainingAt(pos.add(0, 1, 0)) && forge.getFuel() > 0) {
+				world.playSound(null, pos, SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.AMBIENT, 0.5F, 1.0F);
+				//world.spawnParticle(EnumParticleTypes.SMOKE_NORMAL, pos.getX() + 0.5D, pos.getY() - 0.5D, pos.getZ() + 0.5D, 0F, 0.1F, 0F);
+			} else if (!state.getValue(BURNING) && forge.getFuel() > 0) {
+				IIgnitable.playIgnitionSound(world, pos);
+				forge.setIsLit(true);
+				setActiveState(true, forge.getFuelCount(), forge.hasBlockAbove(), world, pos);
+			}
+		}
 	}
 
 	private boolean onUsedTongs(EntityPlayer user, ItemStack held, TileEntityForge tile) {
@@ -285,9 +317,10 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> {
 			if (tile.getIsLit() && !world.isBlockPowered(pos)) {
 				setActiveState(false, tile.getFuelCount(), tile.hasBlockAbove(), world, pos);
 				tile.setIsLit(false);
+				world.playSound(null, pos, SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.AMBIENT, 0.5F, 1.0F);
 			} else if (!tile.getIsLit() && world.isBlockPowered(pos)) {
-				setActiveState(true, tile.getFuelCount(), tile.hasBlockAbove(), world, pos);
-				tile.setIsLit(true);
+				fireItUp(world, pos, state);
+				world.playSound(null, pos, SoundEvents.ITEM_FLINTANDSTEEL_USE, SoundCategory.AMBIENT, 1.0F, 1.0F);
 			}
 		}
 	}
@@ -302,5 +335,4 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> {
 			setActiveState(tile.getIsLit(), tile.getFuelCount(), tile.hasBlockAbove(), world, pos);
 		}
 	}
-
 }

--- a/src/main/java/minefantasy/mfr/block/BlockForge.java
+++ b/src/main/java/minefantasy/mfr/block/BlockForge.java
@@ -77,7 +77,7 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 	@Override
 	public IBlockState getActualState(IBlockState state, IBlockAccess world, BlockPos pos) {
 		TileEntityForge tile = (TileEntityForge) getTile(world, pos);
-		return state.withProperty(BURNING, tile.getIsLit()).withProperty(FUEL_COUNT, tile.getFuelCount()).withProperty(UNDER, tile.hasBlockAbove());
+		return state.withProperty(BURNING, tile.isLit()).withProperty(FUEL_COUNT, tile.getFuelCount()).withProperty(UNDER, tile.hasBlockAbove());
 	}
 
 	@Override
@@ -166,16 +166,16 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 	@Override
 	public boolean isBurning(IBlockAccess world, BlockPos pos) {
 		TileEntityForge tile = (TileEntityForge) getTile(world, pos);
-		return tile != null && tile.getIsLit();
+		return tile != null && tile.isLit();
 	}
 
 	@Override
 	public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
 		ItemStack held = player.getHeldItemMainhand();
-		TileEntityForge forge = (TileEntityForge) getTile(world, pos);
+		TileEntityForge forge = (TileEntityForge) world.getTileEntity(pos);
 		if (forge != null) {
 			// Burn unprotected players
-			if (forge.getIsLit() && !ItemApron.isUserProtected(player)) {
+			if (forge.isLit() && !ItemApron.isUserProtected(player)) {
 				player.setFire(5);
 				player.attackEntityFrom(DamageSource.ON_FIRE, player.isWet() ? 3 : 1);
 				if (!player.world.isRemote) {
@@ -189,7 +189,7 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 				}
 				// Ignition
 				if (held.getItem() instanceof ItemFlintAndSteel || held.getItem() instanceof ILighter) {
-					if (!forge.getIsLit() && forge.getFuel() > 0 && forge.getTier() != 1) {
+					if (!forge.isLit() && forge.getFuel() > 0 && forge.getTier() != 1) {
 						// 1 for ignition, -1 for a failed attempt, 0 for a null input or for an item that needs to bypass normal ignition
 						int uses = ItemLighter.tryUse(held, player);
 						if (uses != 0) {
@@ -314,11 +314,11 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 	public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
 		TileEntityForge tile = (TileEntityForge) getTile(world, pos);
 		if (tier == 1 && !world.isRemote) {
-			if (tile.getIsLit() && !world.isBlockPowered(pos)) {
+			if (tile.isLit() && !world.isBlockPowered(pos)) {
 				setActiveState(false, tile.getFuelCount(), tile.hasBlockAbove(), world, pos);
 				tile.setIsLit(false);
 				world.playSound(null, pos, SoundEvents.BLOCK_FIRE_EXTINGUISH, SoundCategory.AMBIENT, 0.5F, 1.0F);
-			} else if (!tile.getIsLit() && world.isBlockPowered(pos)) {
+			} else if (!tile.isLit() && world.isBlockPowered(pos)) {
 				igniteBlock(world, pos, state);
 				world.playSound(null, pos, SoundEvents.ITEM_FLINTANDSTEEL_USE, SoundCategory.AMBIENT, 1.0F, 1.0F);
 			}
@@ -331,8 +331,8 @@ public class BlockForge extends BlockTileEntity<TileEntityForge> implements IIgn
 	@Override
 	public void updateTick(World world, BlockPos pos, IBlockState state, Random rand) {
 		TileEntityForge tile = (TileEntityForge) getTile(world, pos);
-		if (tier == 1 && !world.isRemote && tile.getIsLit() && !world.isBlockPowered(pos)) {
-			setActiveState(tile.getIsLit(), tile.getFuelCount(), tile.hasBlockAbove(), world, pos);
+		if (tier == 1 && !world.isRemote && tile.isLit() && !world.isBlockPowered(pos)) {
+			setActiveState(tile.isLit(), tile.getFuelCount(), tile.hasBlockAbove(), world, pos);
 		}
 	}
 }

--- a/src/main/java/minefantasy/mfr/client/gui/GuiForge.java
+++ b/src/main/java/minefantasy/mfr/client/gui/GuiForge.java
@@ -44,7 +44,7 @@ public class GuiForge extends GuiContainer {
 		int[] scale = tile.getTempsScaled(53);
 
 		if (this.tile.temperature > 0) {
-			if (this.tile.getIsLit()) {
+			if (this.tile.isLit()) {
 				int heatScM = scale[1];
 				this.drawTexturedModalRect(xPoint + 32, yPoint + 58 - heatScM, 176, 0, 16, 3);
 			}

--- a/src/main/java/minefantasy/mfr/tile/TileEntityBloomery.java
+++ b/src/main/java/minefantasy/mfr/tile/TileEntityBloomery.java
@@ -7,11 +7,9 @@ import minefantasy.mfr.constants.Tool;
 import minefantasy.mfr.container.ContainerBase;
 import minefantasy.mfr.container.ContainerBloomery;
 import minefantasy.mfr.entity.EntityItemHeated;
-import minefantasy.mfr.init.MineFantasyKnowledgeList;
 import minefantasy.mfr.init.MineFantasySounds;
 import minefantasy.mfr.item.ItemHeated;
 import minefantasy.mfr.mechanics.RPGElements;
-import minefantasy.mfr.mechanics.knowledge.ResearchLogic;
 import minefantasy.mfr.network.NetworkHandler;
 import minefantasy.mfr.recipe.BloomeryRecipeBase;
 import minefantasy.mfr.recipe.CraftingManagerBloomery;
@@ -23,8 +21,6 @@ import minefantasy.mfr.util.Utils;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Items;
-import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
@@ -89,6 +85,27 @@ public class TileEntityBloomery extends TileEntityBase implements ITickable {
 		return oldState.getBlock() != newState.getBlock();
 	}
 
+	public boolean getIsActive() {
+		return isActive;
+	}
+
+	public void setIsActive(boolean active) {
+		isActive = active;
+	}
+
+	public void setProgressMax(float newMax) {
+		progressMax = newMax;
+	}
+
+	public float getSmeltTime() {
+		float smeltTime = getInventory().getStackInSlot(0).getCount() * getTime(getInventory().getStackInSlot(0));// 15s per item
+		return smeltTime;
+	}
+
+	private int getTime(ItemStack itemStack) {
+		return 300;
+	}
+
 	public boolean isInput(ItemStack input) {
 		return !getResult(input).isEmpty();
 	}
@@ -112,7 +129,6 @@ public class TileEntityBloomery extends TileEntityBase implements ITickable {
 			return ItemStack.EMPTY;// Cannot smelt if a bloom exists
 		if (input.isEmpty() || coal.isEmpty())
 			return ItemStack.EMPTY;// Needs input
-
 		if (!hasEnoughCarbon(input, coal)) {
 			return ItemStack.EMPTY;
 		}
@@ -153,33 +169,9 @@ public class TileEntityBloomery extends TileEntityBase implements ITickable {
 					sendUpdates();
 				}
 			}
+		} else if (isActive) {
+			isActive = false;
 		}
-	}
-
-	/**
-	 * Light the bloomery, starting the process.
-	 *
-	 * @return true if it can smelt
-	 */
-	public boolean light(EntityPlayer user) {
-		ItemStack res = getResult();
-		if (world.canBlockSeeSky(pos.add(0, 1, 0)) && res != null && !isActive) {
-			if (!world.isRemote) {
-				if (res.getItem() == Items.IRON_INGOT && !ResearchLogic.getResearchCheck(user, MineFantasyKnowledgeList.smelt_iron)) {
-					return false;
-				}
-				isActive = true;
-				progressMax = getInventory().getStackInSlot(0).getCount() * getTime(getInventory().getStackInSlot(0));// 15s per item
-				world.playSound(user, pos.add(0.5D, 0.5D, +0.5D), SoundEvents.ITEM_FLINTANDSTEEL_USE, SoundCategory.AMBIENT, 1.0F, 1.0F);
-			}
-
-			return true;
-		}
-		return false;
-	}
-
-	private int getTime(ItemStack itemStack) {
-		return 300;
 	}
 
 	/**
@@ -259,10 +251,6 @@ public class TileEntityBloomery extends TileEntityBase implements ITickable {
 
 	public void setKnownResearches(Set<String> knownResearches) {
 		this.knownResearches = knownResearches;
-	}
-
-	public boolean isActive() {
-		return isActive;
 	}
 
 	public boolean hasBloom() {

--- a/src/main/java/minefantasy/mfr/tile/TileEntityBloomery.java
+++ b/src/main/java/minefantasy/mfr/tile/TileEntityBloomery.java
@@ -85,7 +85,7 @@ public class TileEntityBloomery extends TileEntityBase implements ITickable {
 		return oldState.getBlock() != newState.getBlock();
 	}
 
-	public boolean getIsActive() {
+	public boolean isActive() {
 		return isActive;
 	}
 

--- a/src/main/java/minefantasy/mfr/tile/TileEntityFirepit.java
+++ b/src/main/java/minefantasy/mfr/tile/TileEntityFirepit.java
@@ -10,6 +10,7 @@ import minefantasy.mfr.init.MineFantasyItems;
 import minefantasy.mfr.mechanics.RPGElements;
 import minefantasy.mfr.util.CustomToolHelper;
 import minefantasy.mfr.util.Functions;
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
@@ -97,7 +98,7 @@ public class TileEntityFirepit extends TileEntityBase implements ITickable, IBas
 	/**
 	 * Gets the burn time
 	 * <p>
-	 * Wood tools and plank item are 1 minute sticks and saplings are 30seconds
+	 * Wood tools and plank item are 1-minute sticks and saplings are 30seconds
 	 */
 	public static int getItemBurnTime(ItemStack input) {
 		if (!input.isEmpty()) {
@@ -135,7 +136,7 @@ public class TileEntityFirepit extends TileEntityBase implements ITickable, IBas
 				}
 			}
 		}
-		if (isLit()) {
+		if (getIsLit()) {
 			if (isWet()) {
 				extinguish();
 				return;
@@ -147,14 +148,14 @@ public class TileEntityFirepit extends TileEntityBase implements ITickable, IBas
 			}
 
 			if (fuel <= 0) {
-				setLit(false);
+				setIsLit(false);
 			}
 		} else if (fuel > 0 && ticksExisted % 10 == 0) {
 			tryLight();
 		}
 	}
 
-	private boolean isWet() {
+	public boolean isWet() {
 		if (isWater(-1, 0, 0) || isWater(1, 0, 0) || isWater(0, 0, -1) || isWater(0, 0, 1) || isWater(0, 1, 0)) {
 			return true;
 		}
@@ -163,22 +164,22 @@ public class TileEntityFirepit extends TileEntityBase implements ITickable, IBas
 	}
 
 	public boolean isBurning() {
-		return isLit() && fuel > 0;
+		return getIsLit() && fuel > 0;
 	}
 
-	public boolean isLit() {
+	public boolean getIsLit() {
 		return isLit;
 	}
 
-	public void setLit(boolean lit) {
-		BlockFirepit.setActiveState(lit, fuel > 0, hasBlockAbove(), world, pos);
+	public void setIsLit(boolean lit) {
 		isLit = lit;
 		ticksExisted = 0;
 	}
 
 	private void tryLight() {
 		if (isFire(-1, 0, 0) || isFire(1, 0, 0) || isFire(0, 0, -1) || isFire(0, 0, 1) || isFire(0, -1, 0) || isFire(0, 1, 0)) {
-			setLit(true);
+			Block block = world.getBlockState(pos).getBlock();
+			((BlockFirepit) block).fireItUp(world, pos, world.getBlockState(pos));
 		}
 	}
 
@@ -248,7 +249,7 @@ public class TileEntityFirepit extends TileEntityBase implements ITickable, IBas
 		world.spawnParticle(EnumParticleTypes.SMOKE_LARGE, pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, 0.0D, 0.0D, 0.0D);
 		world.spawnParticle(EnumParticleTypes.BLOCK_CRACK, pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, 0.0D, 0.0D, 0.0D);
 
-		setLit(false);
+		setIsLit(false);
 		BlockFirepit.setActiveState(isBurning(), fuel > 0, hasBlockAbove(), world, pos);
 	}
 

--- a/src/main/java/minefantasy/mfr/tile/TileEntityFirepit.java
+++ b/src/main/java/minefantasy/mfr/tile/TileEntityFirepit.java
@@ -179,7 +179,7 @@ public class TileEntityFirepit extends TileEntityBase implements ITickable, IBas
 	private void tryLight() {
 		if (isFire(-1, 0, 0) || isFire(1, 0, 0) || isFire(0, 0, -1) || isFire(0, 0, 1) || isFire(0, -1, 0) || isFire(0, 1, 0)) {
 			Block block = world.getBlockState(pos).getBlock();
-			((BlockFirepit) block).fireItUp(world, pos, world.getBlockState(pos));
+			((BlockFirepit) block).igniteBlock(world, pos, world.getBlockState(pos));
 		}
 	}
 

--- a/src/main/java/minefantasy/mfr/tile/TileEntityForge.java
+++ b/src/main/java/minefantasy/mfr/tile/TileEntityForge.java
@@ -144,7 +144,7 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 			sendUpdates();
 		}
 
-		if (!getIsLit() && !world.isRemote) {
+		if (!isLit() && !world.isRemote) {
 			if (temperature > 0 && ticksExisted % 5 == 0) {
 				temperature = 0;
 			}
@@ -156,7 +156,7 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 			return;
 		}
 		boolean isBurning = isBurning();// Check if it's burning
-		float maxTemp = getIsLit() ? (fuelTemperature + getUnderTemperature()) : 0;
+		float maxTemp = isLit() ? (fuelTemperature + getUnderTemperature()) : 0;
 
 		if (temperature < maxTemp) {
 			float amount = 2.0F;
@@ -300,7 +300,7 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 		return stats != null;
 	}
 
-	public boolean getIsLit(){
+	public boolean isLit(){
 		return isLit;
 	}
 
@@ -350,7 +350,7 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 			hasUsed = true;
 			fuel = Math.min(fuel + stats.duration, maxFuel);// Fill as much as can fit
 		}
-		if (stats.doesLight && !getIsLit()) {
+		if (stats.doesLight && !isLit()) {
 			if (!(getTier() == 1)) {
 				Block block = world.getBlockState(pos).getBlock();
 				((BlockForge) block).igniteBlock(world, pos, world.getBlockState(pos));
@@ -360,7 +360,7 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 		if (hasUsed) {
 			fuelTemperature = stats.baseHeat;
 		}
-		BlockForge.setActiveState(getIsLit(), getFuelCount(), hasBlockAbove(), world, pos);
+		BlockForge.setActiveState(isLit(), getFuelCount(), hasBlockAbove(), world, pos);
 		return hasUsed;
 	}
 
@@ -438,7 +438,7 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 	}
 
 	public float getBlockTemperature() {
-		if (this.getIsLit()) {
+		if (this.isLit()) {
 			return temperature;
 		}
 		return 0;
@@ -502,7 +502,7 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 	@SideOnly(Side.CLIENT)
 	public String getTextureName() {
 		BlockForge forge = (BlockForge) world.getBlockState(pos).getBlock();
-		return "forge_" + forge.type + (getIsLit() ? "_active" : "");
+		return "forge_" + forge.type + (isLit() ? "_active" : "");
 	}
 
 	@Override

--- a/src/main/java/minefantasy/mfr/tile/TileEntityForge.java
+++ b/src/main/java/minefantasy/mfr/tile/TileEntityForge.java
@@ -179,6 +179,10 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 		maxFuel = getTier() == 1 ? 12000 : 6000;
 	}
 
+	public float getFuel() {
+		return fuel;
+	}
+
 	public boolean isOutside() {
 		for (int x = -1; x <= 1; x++) {
 			for (int y = -1; y <= 1; y++) {
@@ -316,15 +320,8 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 	}
 
 	/**
-	 * Fires the forge up
+	 * The principle "fire up the forge" function has been moved to the BlockForge class ~Lenvill
 	 */
-	public void fireUpForge() {
-		if (getTier() == 1) {
-			return;
-		}
-		setIsLit(true);
-		BlockForge.setActiveState(true, getFuelCount(), hasBlockAbove(), world, pos);
-	}
 
 	public float getBellowsEffect() {
 		return getTier() == 1 ? 2.0F : 1.5F;
@@ -354,7 +351,10 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 			fuel = Math.min(fuel + stats.duration, maxFuel);// Fill as much as can fit
 		}
 		if (stats.doesLight && !getIsLit()) {
-			fireUpForge();
+			if (!(getTier() == 1)) {
+				Block block = world.getBlockState(pos).getBlock();
+				((BlockForge) block).fireItUp(world, pos, world.getBlockState(pos));
+			}
 			hasUsed = true;
 		}
 		if (hasUsed) {

--- a/src/main/java/minefantasy/mfr/tile/TileEntityForge.java
+++ b/src/main/java/minefantasy/mfr/tile/TileEntityForge.java
@@ -353,7 +353,7 @@ public class TileEntityForge extends TileEntityBase implements IBasicMetre, IHea
 		if (stats.doesLight && !getIsLit()) {
 			if (!(getTier() == 1)) {
 				Block block = world.getBlockState(pos).getBlock();
-				((BlockForge) block).fireItUp(world, pos, world.getBlockState(pos));
+				((BlockForge) block).igniteBlock(world, pos, world.getBlockState(pos));
 			}
 			hasUsed = true;
 		}


### PR DESCRIPTION
Build.Gradle:
- Added a "sourceSets.all" block to make bugtesting easier
- Removed duplicate implementation of JEI

IIgnitable:
- Added IIgnitable interface for all blocks that can be ignited. Has a static "playIgnitionSound" method that plays a slightly randomized ignition sound at target block, and requires all classes it is applied to to implement a "fireItUp" function that other things can now reference to ignite those blocks.

For each of BlockBloomery, BlockFirepit, and BlockForge:
- Gave it the IIgnitable interface
- Annotated elements "onBlockActivated" method
- Reworked the section of "onBlockActivated" that handles ignition. Is now near identical across all blocks
- Added implementation of FireItUp, which checks all block-and-tile-related conditions influencing whether or not the IIgnitable can ignite, and if it can ignite, puts it into an ignited state.
- All blocks now play a pitch-shifted fire charge sound when ignited, instead of just the firepit
- Blocks only fire fireItUp on the server side to avoid the false start bug when the random success chance rolled a success on the client side but failed on the server side
- If clicked on with an instance of IIgniter that has its "canLight" boolean set to false, it will end the interact process. I did this intentionally to make implimentinng support for pyrotech's weird lighters easier, but it can also be put on any item if it should not open up the GUI of the block in question

BlockBloomery:
- Now has ignition sound
- If unable to be ignited, right clicking on it with an igniter will open the GUI
- Fixed ignition check to solve the issues of the bloomery being ignited and stuck in an active state if ignited when totally empty, and entering a false start when fuel and ore didn't match.

BlockFirepit
- Changed unsuccessful ignition sound to the same flint and steel click as other blocks
- If clicked on by an igniter while lacking fuel, will precent the igniter from trying to set fire to an adjacent block
- If an attempt to ignite it in the rain is made, it will make a sizzle noise without ever entering an active state

BlockForge
- Can no longer be activated when its top is exposed to the rain. It will make a sizzle if the presence of rain prevents its activation
- No longer flashes when ignited when it has no fuel in it
- Auto-igniting forges now make a noise when being ignited and when being extinguished.

ItemLighter
- tryUse now returns a 0 if the ILighter canLlight boolean is false. Used to bypass normal ignition steps.
- Added @Nonnull annotation to EnumActionResult because IntelliJ told me to
- ILighters now only light fires on the server side. This is done to fix the bug where a client-side-only fire would briefly appear when it rolled a successful ignition on the client but a failed ignition on the server

TileEntityBloomery
- Renamed isActive() to getIsActive()
- Added setIsActive method
- added setProgressMax method
- Added check to Update() method to set isActive to false if it was true but it has no fuel.
- Removed AP's old light() function, as the ignition process is now handled on the block side.

TileEntityFirepit
- Renamed isLit() to getIsLit()
- Renamed isLit() to setIsLit()
- changed isWet from private to public
- tryLight() uses fireItUp() to handle igition

TileEntityForge
- Added getFuel() method
- Removed the fireUpForge() method, as that is now handled by the fireItUp() method in the block class
- Changed addFuel to use fireItUp() when a hot fuel is added to the forge, which means it will play the whoosh noise